### PR TITLE
Make recommenders pluggable and choosable via command-line

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -2,6 +2,7 @@
 <classpath>
 	<classpathentry kind="src" path="src/main/java"/>
 	<classpathentry kind="src" path="src/test/java"/>
+	<classpathentry kind="src" path="src/main/resources"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>

--- a/pom.xml
+++ b/pom.xml
@@ -4,14 +4,13 @@
   <artifactId>SuiteGenerator</artifactId>
   <version>0.0.1-SNAPSHOT</version>
   <build>
-    <sourceDirectory>src</sourceDirectory>
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.3</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
     </plugins>
@@ -22,6 +21,7 @@
     		<groupId>junit</groupId>
    			<artifactId>junit</artifactId>
     		<version>4.12</version>
+    		<scope>test</scope>
 		</dependency>
 		<dependency>
     		<groupId>org.apache.poi</groupId>
@@ -42,6 +42,11 @@
     		<groupId>org.jdom</groupId>
     		<artifactId>jdom2</artifactId>
     		<version>2.0.6</version>
+		</dependency>
+		<dependency>
+		    <groupId>commons-cli</groupId>
+		    <artifactId>commons-cli</artifactId>
+		    <version>1.2</version>
 		</dependency>
     </dependencies>
 </project>

--- a/src/main/java/net/bpelunit/suitegenerator/Executor.java
+++ b/src/main/java/net/bpelunit/suitegenerator/Executor.java
@@ -2,28 +2,61 @@ package net.bpelunit.suitegenerator;
 
 import java.io.File;
 
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.PosixParser;
+
 import net.bpelunit.suitegenerator.config.Config;
+import net.bpelunit.suitegenerator.recommendation.IRecommender;
+import net.bpelunit.suitegenerator.recommendation.RecommenderFactory;
+import net.bpelunit.suitegenerator.recommendation.permut.Permutation;
 
 public class Executor {
 
-	private static boolean createRecommendations = true;
+	private static boolean createRecommendations = false;
 	private static boolean createNewTestCases = false;
+	private static IRecommender recommender = new Permutation();
+	private static RecommenderFactory recommenderFactory = new RecommenderFactory();
+	private static File projectFolder = new File("files/suite/");
+	private static String targetSuiteFileName;
 
-	public static void main(String[] args) {
-		File folder;
-		if(args.length >= 1) {
-			folder = new File(args[0]);
+	public static void main(String[] args) throws Exception {
+		
+		Options options = new Options();
+		options.addOption("s", true, "Test Suite File relative to the project directory");
+		options.addOption("r", false, "Create Recommendations");
+		options.addOption("g", false, "Generate Test Cases based on recommendations (implies -r)");
+		options.addOption("recommender", true, "Logical Name of a recommender to use. Defaults to permut.");
+		options.addOption("recommenderclass", true, "A full qualified class name of the recommender to use. Overrides recommender.");
+		
+		CommandLineParser parser = new PosixParser();
+		CommandLine cmd = parser.parse(options, args);
+		
+		if(cmd.hasOption("r")) {
+			createRecommendations = true;
+		}
+		if(cmd.hasOption("g")) {
+			createRecommendations = true;
+			createNewTestCases = true;
+		}
+		if(cmd.hasOption("s")) {
+			targetSuiteFileName = cmd.getOptionValue("s"); 
 		} else {
-			folder = new File("files/suite/");
+			targetSuiteFileName = Config.get().getOutputName();
+		}
+		if(cmd.hasOption("recommenderclass")) {
+			recommender = recommenderFactory.getRecommenderByClassname(cmd.getOptionValue("recommenderclass"));
+		} else if (cmd.hasOption("recommender")) {
+			recommender = recommenderFactory.getRecommenderByName(cmd.getOptionValue("recommender"));
 		}
 		
-		String targetSuiteFileName = Config.get().getOutputName();
-		if(args.length >= 2) {
-			targetSuiteFileName = args[1];
+		if(cmd.getArgList().size() > 0) {
+			projectFolder = new File(cmd.getArgList().get(0).toString());
 		}
 		
-		Generator g = new Generator(new File(folder, Config.get().getClassificationTableName()));
-		g.generate(folder, createRecommendations, createNewTestCases, targetSuiteFileName);
+		Generator g = new Generator(new File(projectFolder, Config.get().getClassificationTableName()));
+		g.generate(projectFolder, createRecommendations ? recommender : null, createNewTestCases, targetSuiteFileName);
 	}
 
 }

--- a/src/main/java/net/bpelunit/suitegenerator/Generator.java
+++ b/src/main/java/net/bpelunit/suitegenerator/Generator.java
@@ -8,8 +8,7 @@ import net.bpelunit.suitegenerator.datastructures.variables.DataVariableInstance
 import net.bpelunit.suitegenerator.reader.IClassificationReader;
 import net.bpelunit.suitegenerator.reader.ICodeFragmentReader;
 import net.bpelunit.suitegenerator.reader.ReaderFactory;
-import net.bpelunit.suitegenerator.recommendation.Recommender;
-import net.bpelunit.suitegenerator.recommendation.permut.Permutation;
+import net.bpelunit.suitegenerator.recommendation.IRecommender;
 import net.bpelunit.suitegenerator.statistics.IStatistics;
 import net.bpelunit.suitegenerator.statistics.Statistics;
 import net.bpelunit.suitegenerator.suitebuilder.SuiteBuilder;
@@ -31,7 +30,7 @@ public class Generator {
 		Config.get().out().printClassificationTree(tree);
 	}
 
-	public void generate(File folder, boolean createRecommendations, boolean createNewTestCases, String suiteFileName) {
+	public void generate(File folder, IRecommender recommender, boolean createNewTestCases, String suiteFileName) {
 		SuiteBuilder sb = new SuiteBuilder();
 		sb.buildSuite(fragmentReader.getSkeletalStructure(), classificationReader.getClassification(), folder,
 				fragmentReader);
@@ -46,12 +45,11 @@ public class Generator {
 				// System.out.println(d.getVariableName() + ":" + d.getInstanceName() + ": " + d.getNumberUsages());
 			}
 		}
-		if (createRecommendations) {
-			Recommender r = new Permutation(stat, fragmentReader.getVariables(),
-					classificationReader.getClassification());
-			Config.get().out().printRecommendation(r.getRecommendations());
+		if (recommender != null) {
+			recommender.setClassificationData(stat, fragmentReader.getVariables(), classificationReader.getClassification());
+			Config.get().out().printRecommendation(recommender.getRecommendations());
 			if (createNewTestCases) {
-				sb.addRecommendations(r);
+				sb.addRecommendations(recommender);
 			}
 		}
 		

--- a/src/main/java/net/bpelunit/suitegenerator/datastructures/classification/Classification.java
+++ b/src/main/java/net/bpelunit/suitegenerator/datastructures/classification/Classification.java
@@ -4,8 +4,8 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 
+import net.bpelunit.suitegenerator.datastructures.conditions.ICondition;
 import net.bpelunit.suitegenerator.datastructures.testcases.TestCase;
-import net.bpelunit.suitegenerator.recommendation.permut.ICondition;
 
 public class Classification {
 

--- a/src/main/java/net/bpelunit/suitegenerator/datastructures/conditions/AND.java
+++ b/src/main/java/net/bpelunit/suitegenerator/datastructures/conditions/AND.java
@@ -1,18 +1,18 @@
-package net.bpelunit.suitegenerator.recommendation.permut;
+package net.bpelunit.suitegenerator.datastructures.conditions;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class XOR implements ICondition {
+public class AND implements ICondition {
 
 	private ICondition first, second;
 
-	public XOR(ICondition first, ICondition second) {
+	public AND(ICondition first, ICondition second) {
 		this.first = first;
 		this.second = second;
 	}
 
-	public XOR() {
+	public AND() {
 
 	}
 
@@ -26,15 +26,15 @@ public class XOR implements ICondition {
 	}
 
 	/**
-	 * Returns true if exactly one of the contained conditions holds for the given Operands
+	 * Returns true if both contained conditions hold for the given Operands
 	 */
 	@Override
 	public boolean evaluate(List<? extends IOperand> ops) {
-		return first.evaluate(ops) ^ second.evaluate(ops);
+		return first.evaluate(ops) && second.evaluate(ops);
 	}
 
 	/**
-	 * Returns true if exactly one of the contained conditions holds for the given Operands
+	 * Returns true if both contained conditions hold for the given Operands
 	 */
 	@Override
 	public boolean evaluate(List<? extends IOperand> ops, IOperand additional) {
@@ -44,7 +44,7 @@ public class XOR implements ICondition {
 	}
 
 	/**
-	 * Returns true if exactly one of the contained conditions holds for the given Operands
+	 * Returns true if both contained conditions hold for the given Operands
 	 */
 	@Override
 	public boolean evaluate(IOperand... ops) {
@@ -58,9 +58,9 @@ public class XOR implements ICondition {
 	@Override
 	public String toString() {
 		if (first == null || second == null) {
-			return "XOR";
+			return "AND";
 		}
-		return "(" + first + " ^ " + second + ")";
+		return "(" + first + " && " + second + ")";
 	}
 
 }

--- a/src/main/java/net/bpelunit/suitegenerator/datastructures/conditions/ConditionBundle.java
+++ b/src/main/java/net/bpelunit/suitegenerator/datastructures/conditions/ConditionBundle.java
@@ -1,4 +1,4 @@
-package net.bpelunit.suitegenerator.recommendation.permut;
+package net.bpelunit.suitegenerator.datastructures.conditions;
 
 import java.util.ArrayList;
 import java.util.LinkedList;

--- a/src/main/java/net/bpelunit/suitegenerator/datastructures/conditions/ConditionParser.java
+++ b/src/main/java/net/bpelunit/suitegenerator/datastructures/conditions/ConditionParser.java
@@ -1,4 +1,4 @@
-package net.bpelunit.suitegenerator.recommendation.permut;
+package net.bpelunit.suitegenerator.datastructures.conditions;
 
 import java.util.LinkedList;
 import java.util.List;

--- a/src/main/java/net/bpelunit/suitegenerator/datastructures/conditions/ICondition.java
+++ b/src/main/java/net/bpelunit/suitegenerator/datastructures/conditions/ICondition.java
@@ -1,4 +1,4 @@
-package net.bpelunit.suitegenerator.recommendation.permut;
+package net.bpelunit.suitegenerator.datastructures.conditions;
 
 import java.util.List;
 

--- a/src/main/java/net/bpelunit/suitegenerator/datastructures/conditions/IOperand.java
+++ b/src/main/java/net/bpelunit/suitegenerator/datastructures/conditions/IOperand.java
@@ -1,0 +1,7 @@
+package net.bpelunit.suitegenerator.datastructures.conditions;
+
+public interface IOperand {
+
+	public String getOpName();
+
+}

--- a/src/main/java/net/bpelunit/suitegenerator/datastructures/conditions/NOT.java
+++ b/src/main/java/net/bpelunit/suitegenerator/datastructures/conditions/NOT.java
@@ -1,4 +1,4 @@
-package net.bpelunit.suitegenerator.recommendation.permut;
+package net.bpelunit.suitegenerator.datastructures.conditions;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/net/bpelunit/suitegenerator/datastructures/conditions/OR.java
+++ b/src/main/java/net/bpelunit/suitegenerator/datastructures/conditions/OR.java
@@ -1,18 +1,18 @@
-package net.bpelunit.suitegenerator.recommendation.permut;
+package net.bpelunit.suitegenerator.datastructures.conditions;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class AND implements ICondition {
+public class OR implements ICondition {
 
 	private ICondition first, second;
 
-	public AND(ICondition first, ICondition second) {
+	public OR(ICondition first, ICondition second) {
 		this.first = first;
 		this.second = second;
 	}
 
-	public AND() {
+	public OR() {
 
 	}
 
@@ -26,15 +26,15 @@ public class AND implements ICondition {
 	}
 
 	/**
-	 * Returns true if both contained conditions hold for the given Operands
+	 * Returns true if either of the contained conditions holds for the given Operands
 	 */
 	@Override
 	public boolean evaluate(List<? extends IOperand> ops) {
-		return first.evaluate(ops) && second.evaluate(ops);
+		return first.evaluate(ops) || second.evaluate(ops);
 	}
 
 	/**
-	 * Returns true if both contained conditions hold for the given Operands
+	 * Returns true if either of the contained conditions holds for the given Operands
 	 */
 	@Override
 	public boolean evaluate(List<? extends IOperand> ops, IOperand additional) {
@@ -44,7 +44,7 @@ public class AND implements ICondition {
 	}
 
 	/**
-	 * Returns true if both contained conditions hold for the given Operands
+	 * Returns true if either of the contained conditions holds for the given Operands
 	 */
 	@Override
 	public boolean evaluate(IOperand... ops) {
@@ -58,9 +58,9 @@ public class AND implements ICondition {
 	@Override
 	public String toString() {
 		if (first == null || second == null) {
-			return "AND";
+			return "OR";
 		}
-		return "(" + first + " && " + second + ")";
+		return "(" + first + " || " + second + ")";
 	}
 
 }

--- a/src/main/java/net/bpelunit/suitegenerator/datastructures/conditions/OperandCondition.java
+++ b/src/main/java/net/bpelunit/suitegenerator/datastructures/conditions/OperandCondition.java
@@ -1,4 +1,4 @@
-package net.bpelunit.suitegenerator.recommendation.permut;
+package net.bpelunit.suitegenerator.datastructures.conditions;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/net/bpelunit/suitegenerator/datastructures/conditions/XOR.java
+++ b/src/main/java/net/bpelunit/suitegenerator/datastructures/conditions/XOR.java
@@ -1,18 +1,18 @@
-package net.bpelunit.suitegenerator.recommendation.permut;
+package net.bpelunit.suitegenerator.datastructures.conditions;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class OR implements ICondition {
+public class XOR implements ICondition {
 
 	private ICondition first, second;
 
-	public OR(ICondition first, ICondition second) {
+	public XOR(ICondition first, ICondition second) {
 		this.first = first;
 		this.second = second;
 	}
 
-	public OR() {
+	public XOR() {
 
 	}
 
@@ -26,15 +26,15 @@ public class OR implements ICondition {
 	}
 
 	/**
-	 * Returns true if either of the contained conditions holds for the given Operands
+	 * Returns true if exactly one of the contained conditions holds for the given Operands
 	 */
 	@Override
 	public boolean evaluate(List<? extends IOperand> ops) {
-		return first.evaluate(ops) || second.evaluate(ops);
+		return first.evaluate(ops) ^ second.evaluate(ops);
 	}
 
 	/**
-	 * Returns true if either of the contained conditions holds for the given Operands
+	 * Returns true if exactly one of the contained conditions holds for the given Operands
 	 */
 	@Override
 	public boolean evaluate(List<? extends IOperand> ops, IOperand additional) {
@@ -44,7 +44,7 @@ public class OR implements ICondition {
 	}
 
 	/**
-	 * Returns true if either of the contained conditions holds for the given Operands
+	 * Returns true if exactly one of the contained conditions holds for the given Operands
 	 */
 	@Override
 	public boolean evaluate(IOperand... ops) {
@@ -58,9 +58,9 @@ public class OR implements ICondition {
 	@Override
 	public String toString() {
 		if (first == null || second == null) {
-			return "OR";
+			return "XOR";
 		}
-		return "(" + first + " || " + second + ")";
+		return "(" + first + " ^ " + second + ")";
 	}
 
 }

--- a/src/main/java/net/bpelunit/suitegenerator/reader/XLSReader.java
+++ b/src/main/java/net/bpelunit/suitegenerator/reader/XLSReader.java
@@ -21,10 +21,10 @@ import net.bpelunit.suitegenerator.datastructures.classification.ClassificationT
 import net.bpelunit.suitegenerator.datastructures.classification.ClassificationVariable;
 import net.bpelunit.suitegenerator.datastructures.classification.ClassificationVariableSelection;
 import net.bpelunit.suitegenerator.datastructures.classification.IClassificationElement;
+import net.bpelunit.suitegenerator.datastructures.conditions.ConditionBundle;
+import net.bpelunit.suitegenerator.datastructures.conditions.ConditionParser;
+import net.bpelunit.suitegenerator.datastructures.conditions.ICondition;
 import net.bpelunit.suitegenerator.datastructures.testcases.TestCase;
-import net.bpelunit.suitegenerator.recommendation.permut.ConditionBundle;
-import net.bpelunit.suitegenerator.recommendation.permut.ConditionParser;
-import net.bpelunit.suitegenerator.recommendation.permut.ICondition;
 import net.bpelunit.suitegenerator.statistics.IStatistics;
 
 public class XLSReader implements IClassificationReader {

--- a/src/main/java/net/bpelunit/suitegenerator/recommendation/IRecommender.java
+++ b/src/main/java/net/bpelunit/suitegenerator/recommendation/IRecommender.java
@@ -1,0 +1,15 @@
+package net.bpelunit.suitegenerator.recommendation;
+
+import java.util.Collection;
+
+import net.bpelunit.suitegenerator.datastructures.classification.Classification;
+import net.bpelunit.suitegenerator.datastructures.variables.VariableLibrary;
+import net.bpelunit.suitegenerator.statistics.IStatistics;
+
+public interface IRecommender {
+
+	Collection<Recommendation> getRecommendations();
+
+	void setClassificationData(IStatistics stat, VariableLibrary variables, Classification classification);
+
+}

--- a/src/main/java/net/bpelunit/suitegenerator/recommendation/Recommender.java
+++ b/src/main/java/net/bpelunit/suitegenerator/recommendation/Recommender.java
@@ -7,13 +7,13 @@ import java.util.Map;
 
 import net.bpelunit.suitegenerator.datastructures.classification.Classification;
 import net.bpelunit.suitegenerator.datastructures.classification.ClassificationVariable;
+import net.bpelunit.suitegenerator.datastructures.conditions.ICondition;
 import net.bpelunit.suitegenerator.datastructures.variables.VariableLibrary;
-import net.bpelunit.suitegenerator.recommendation.permut.ICondition;
 import net.bpelunit.suitegenerator.statistics.IStatistics;
 import net.bpelunit.suitegenerator.statistics.Selection;
 import net.bpelunit.suitegenerator.util.Copy;
 
-public class Recommender {
+public abstract class Recommender implements IRecommender {
 
 	protected IStatistics statistic;
 	protected VariableLibrary variables;
@@ -22,17 +22,14 @@ public class Recommender {
 
 	protected List<Recommendation> recommendations = null;
 
-	public Recommender(IStatistics statistic, VariableLibrary variables, Classification classification) {
-		this.statistic = statistic;
-		this.variables = variables;
-		this.classification = classification;
-		this.forbidden = classification.getForbidden();
+	public Recommender() {
 	}
 
 	protected void createRecommendations() {
 		recommendations = new LinkedList<>();
 	}
 
+	@Override
 	public List<Recommendation> getRecommendations() {
 		if (recommendations == null) {
 			createRecommendations();
@@ -58,6 +55,14 @@ public class Recommender {
 			}
 		}
 		return least;
+	}
+
+	@Override
+	public void setClassificationData(IStatistics stat, VariableLibrary variables, Classification classification) {
+		this.statistic = stat;
+		this.variables = variables;
+		this.classification = classification;
+		this.forbidden = classification.getForbidden();
 	}
 
 }

--- a/src/main/java/net/bpelunit/suitegenerator/recommendation/RecommenderFactory.java
+++ b/src/main/java/net/bpelunit/suitegenerator/recommendation/RecommenderFactory.java
@@ -1,0 +1,41 @@
+package net.bpelunit.suitegenerator.recommendation;
+
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.Properties;
+
+public class RecommenderFactory {
+
+	private static final String SYSPROPERTYNAME_RECOMMENDERFACTORY_PROPERTIES = "recommenderfactory.properties";
+	private Properties properties = null;
+	
+	public IRecommender getRecommenderByName(String name) {
+		try {
+			
+			if(properties == null) {
+				readProperties();
+			}
+			return getRecommenderByClassname(properties.getProperty(name));
+		
+		} catch (Exception e) {
+			throw new RuntimeException("Illegal RecommenderFactory configuration", e);
+		}
+	}
+	
+	private void readProperties() throws FileNotFoundException, IOException {
+		properties = new Properties();
+		String propertiesFilename = System.getProperty(SYSPROPERTYNAME_RECOMMENDERFACTORY_PROPERTIES);
+		if(propertiesFilename != null) {
+			properties.load(new FileInputStream(propertiesFilename));
+		} else {
+			properties.load(getClass().getResourceAsStream("recommenderfactory.properties"));
+		}
+		
+	}
+
+	public IRecommender getRecommenderByClassname(String className) throws Exception {
+		return (IRecommender) Class.forName(className).newInstance();
+	}
+	
+}

--- a/src/main/java/net/bpelunit/suitegenerator/recommendation/SimpleRecommender.java
+++ b/src/main/java/net/bpelunit/suitegenerator/recommendation/SimpleRecommender.java
@@ -8,10 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import net.bpelunit.suitegenerator.datastructures.classification.Classification;
 import net.bpelunit.suitegenerator.datastructures.classification.ClassificationVariable;
-import net.bpelunit.suitegenerator.datastructures.variables.VariableLibrary;
-import net.bpelunit.suitegenerator.statistics.IStatistics;
 import net.bpelunit.suitegenerator.statistics.Selection;
 import net.bpelunit.suitegenerator.util.Copy;
 
@@ -23,8 +20,7 @@ public class SimpleRecommender extends Recommender {
 	private Collection<Selection> allSelections;
 	private Map<ClassificationVariable, List<Selection>> roots;
 
-	public SimpleRecommender(IStatistics statistic, VariableLibrary variables, Classification classification) {
-		super(statistic, variables, classification);
+	public SimpleRecommender() {
 	}
 
 	@Override

--- a/src/main/java/net/bpelunit/suitegenerator/recommendation/VarInstanceBasedRecommender.java
+++ b/src/main/java/net/bpelunit/suitegenerator/recommendation/VarInstanceBasedRecommender.java
@@ -8,12 +8,9 @@ import java.util.Map;
 import java.util.Set;
 
 import net.bpelunit.suitegenerator.config.Config;
-import net.bpelunit.suitegenerator.datastructures.classification.Classification;
 import net.bpelunit.suitegenerator.datastructures.classification.ClassificationVariable;
 import net.bpelunit.suitegenerator.datastructures.variables.DataVariableInstance;
 import net.bpelunit.suitegenerator.datastructures.variables.Mapping;
-import net.bpelunit.suitegenerator.datastructures.variables.VariableLibrary;
-import net.bpelunit.suitegenerator.statistics.IStatistics;
 import net.bpelunit.suitegenerator.statistics.Selection;
 import net.bpelunit.suitegenerator.util.Copy;
 
@@ -23,9 +20,7 @@ public class VarInstanceBasedRecommender extends Recommender {
 	private Map<ClassificationVariable, List<Selection>> roots;
 	private Set<DataVariableInstance> unusedData;
 
-	public VarInstanceBasedRecommender(IStatistics statistic, VariableLibrary variables,
-			Classification classification) {
-		super(statistic, variables, classification);
+	public VarInstanceBasedRecommender() {
 	}
 
 	@Override

--- a/src/main/java/net/bpelunit/suitegenerator/recommendation/permut/IOperand.java
+++ b/src/main/java/net/bpelunit/suitegenerator/recommendation/permut/IOperand.java
@@ -1,7 +1,0 @@
-package net.bpelunit.suitegenerator.recommendation.permut;
-
-public interface IOperand {
-
-	public String getOpName();
-
-}

--- a/src/main/java/net/bpelunit/suitegenerator/recommendation/permut/Pair.java
+++ b/src/main/java/net/bpelunit/suitegenerator/recommendation/permut/Pair.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 
 import net.bpelunit.suitegenerator.datastructures.classification.ClassificationVariable;
+import net.bpelunit.suitegenerator.datastructures.conditions.ICondition;
 import net.bpelunit.suitegenerator.statistics.Selection;
 
 public class Pair {

--- a/src/main/java/net/bpelunit/suitegenerator/recommendation/permut/Pairs.java
+++ b/src/main/java/net/bpelunit/suitegenerator/recommendation/permut/Pairs.java
@@ -7,6 +7,7 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 
 import net.bpelunit.suitegenerator.datastructures.classification.ClassificationVariable;
+import net.bpelunit.suitegenerator.datastructures.conditions.ICondition;
 import net.bpelunit.suitegenerator.statistics.Selection;
 
 public class Pairs {

--- a/src/main/java/net/bpelunit/suitegenerator/recommendation/permut/Permutation.java
+++ b/src/main/java/net/bpelunit/suitegenerator/recommendation/permut/Permutation.java
@@ -24,8 +24,12 @@ public class Permutation extends Recommender {
 	private List<Test> tests = new LinkedList<>();
 	Map<ClassificationVariable, List<Selection>> roots;
 
-	public Permutation(IStatistics statistic, VariableLibrary variables, Classification classification) {
-		super(statistic, variables, classification);
+	public Permutation() {
+	}
+
+	@Override
+	public void setClassificationData(IStatistics stat, VariableLibrary variables, Classification classification) {
+		super.setClassificationData(stat, variables, classification);
 		pairs = new Pairs(forbidden);
 		roots = copyHashMap(new HashMap<ClassificationVariable, List<Selection>>(), statistic.getRootVariables());
 
@@ -34,7 +38,7 @@ public class Permutation extends Recommender {
 		pairs.setupDone();
 		createTests();
 	}
-
+	
 	@Override
 	protected void createRecommendations() {
 		super.createRecommendations();

--- a/src/main/java/net/bpelunit/suitegenerator/statistics/Selection.java
+++ b/src/main/java/net/bpelunit/suitegenerator/statistics/Selection.java
@@ -3,7 +3,7 @@ package net.bpelunit.suitegenerator.statistics;
 import net.bpelunit.suitegenerator.datastructures.classification.ClassificationVariable;
 import net.bpelunit.suitegenerator.datastructures.classification.ClassificationVariableSelection;
 import net.bpelunit.suitegenerator.datastructures.classification.IClassificationElement;
-import net.bpelunit.suitegenerator.recommendation.permut.IOperand;
+import net.bpelunit.suitegenerator.datastructures.conditions.IOperand;
 import net.bpelunit.suitegenerator.util.Copyable;
 
 public class Selection implements Copyable<Selection>, IOperand {

--- a/src/main/java/net/bpelunit/suitegenerator/suitebuilder/SuiteBuilder.java
+++ b/src/main/java/net/bpelunit/suitegenerator/suitebuilder/SuiteBuilder.java
@@ -18,8 +18,8 @@ import net.bpelunit.suitegenerator.datastructures.classification.ClassificationV
 import net.bpelunit.suitegenerator.datastructures.testcases.TestCase;
 import net.bpelunit.suitegenerator.datastructures.variables.VariableLibrary;
 import net.bpelunit.suitegenerator.reader.ICodeFragmentReader;
+import net.bpelunit.suitegenerator.recommendation.IRecommender;
 import net.bpelunit.suitegenerator.recommendation.Recommendation;
-import net.bpelunit.suitegenerator.recommendation.Recommender;
 import net.bpelunit.suitegenerator.util.XMLElementOutput;
 
 public class SuiteBuilder {
@@ -74,7 +74,7 @@ public class SuiteBuilder {
 		}
 	}
 
-	public void addRecommendations(Recommender recommender) {
+	public void addRecommendations(IRecommender recommender) {
 		int num = 1;
 		for (Recommendation r : recommender.getRecommendations()) {
 			List<String> classificationNames = new ArrayList<>();

--- a/src/main/resources/net/bpelunit/suitegenerator/recommendation/recommenderfactory.properties
+++ b/src/main/resources/net/bpelunit/suitegenerator/recommendation/recommenderfactory.properties
@@ -1,0 +1,3 @@
+permut=net.bpelunit.suitegenerator.recommendation.permut.Permutation
+simple=net.bpelunit.suitegenerator.recommendation.SimpleRecommender
+varinstance=net.bpelunit.suitegenerator.recommendation.VarInstanceBasedRecommender

--- a/src/test/java/net/bpelunit/suitegenerator/tests/ConditionReaderTest.java
+++ b/src/test/java/net/bpelunit/suitegenerator/tests/ConditionReaderTest.java
@@ -4,7 +4,7 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
-import net.bpelunit.suitegenerator.recommendation.permut.ConditionParser;
+import net.bpelunit.suitegenerator.datastructures.conditions.ConditionParser;
 
 public class ConditionReaderTest {
 


### PR DESCRIPTION
In the future, research users will need to develop new recommenders and integrate them into the generator. Thus, a pluggable architecture is needed, which allows a) developers to easily write new recommenders and b) users to select a recommender on the command-line.